### PR TITLE
Fix: hasCameraPermission() does not handle new format that "permissions" binary yields

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ const didStopRecording = ({state}) => {
 };
 
 const configDescription =
-`Create a window showing the selected camera on the bottom-left corner of the recording.
+  `Create a window showing the selected camera on the bottom-left corner of the recording.
 The window is click-through and its hover opacity and size can be adjusted.
 
 To move the window, hold Command before you hover over it, then click and drag it anywhere on the screen.
@@ -130,7 +130,8 @@ const openSystemPreferences = path => shell.openExternal(`x-apple.systempreferen
 
 const hasCameraPermission = async () => {
   try {
-    return (await execa(permissionsBinary)).stdout === 'true';
+    const permission = await execa(permissionsBinary);
+    return permission.stdout === 'true' || permission.stdout.split(/\r?\n/).indexOf('true') >= 0;
   } catch {
     return false;
   }


### PR DESCRIPTION
# Story
I've been using `kap-camera` on Big Sur for some time and it was working fine using built-in webcam for MacBook Pro 2018. I decided to use external webcams, as soon as I added the new webcams (Sony ZV-1 and iPhone as webcam via EpocCam), kap-camera stopped working. I was getting the "kap-camera does not have access to camera error" while Kap had access. I did a bit of debugging and found the issue.

## Issue
I noticed that the code depends on the below function to return true:

```js
const hasCameraPermission = async () => {
  try {
    return (await execa(permissionsBinary)).stdout === 'true';
  } catch {
    return false;
  }
}
```

which expected the binary to print "true". At least in my case, it doesn't only print "true".

This is the log I get when I run "permission" binary manually.

```
C:/> ./permissions
Changed waitThread to realtime priority!
2021-01-08 11:01:48.014 permissions[4478:57913] CMIOMS: PlugInMain
2021-01-08 11:01:48.014 permissions[4478:57913] CMIOMS: HardwarePlugIn_QueryInterface
2021-01-08 11:01:48.014 permissions[4478:57913] CMIOMS: HardwarePlugIn_Release sRefCount now = 0
2021-01-08 11:01:48.014 permissions[4478:57913] CMIOMS: HardwarePlugIn_InitializeWithObjectID self=0x108940710
2021-01-08 11:01:48.014 permissions[4478:57913] LvdlServer	ImgReciever
2021-01-08 11:01:48.014 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectGetPropertyData Device(36) kCMIODevicePropertyDeviceUID self=0x108940710 data(id)=054c
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectGetPropertyData Device(36) kCMIODevicePropertyTransportType self=0x108940710 data(int)=1651274862
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectSetPropertyData Device(36) kCMIOObjectPropertyListenerAdded self=0x108940710 data(int)=1684629094
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: Device unhandled setPropertyDataWithAddress for kCMIOObjectPropertyListenerAdded
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectSetPropertyData Device(36) kCMIOObjectPropertyListenerAdded self=0x108940710 data(int)=1869180523
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: Device unhandled setPropertyDataWithAddress for kCMIOObjectPropertyListenerAdded
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectSetPropertyData Device(36) kCMIOObjectPropertyListenerAdded self=0x108940710 data(int)=1885762592
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: Device unhandled setPropertyDataWithAddress for kCMIOObjectPropertyListenerAdded
2021-01-08 11:01:48.015 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectGetPropertyData Stream(37) kCMIOStreamPropertyDirection self=0x108940710 data(int)=1
2021-01-08 11:01:48.031 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectGetPropertyData Device(36) kCMIODevicePropertyDeviceCanBeDefaultDevice self=0x108940710 data(int)=1
2021-01-08 11:01:48.031 permissions[4478:57913] CMIOMS: HardwarePlugIn_ObjectGetPropertyData Device(36) kCMIODevicePropertyHogMode self=0x108940710 data(int)=-1
true
2021-01-08 11:01:48.046 permissions[4478:57913] CMIOMS: HardwarePlugIn_Teardown self=0x108940710
```

## Solution
Not sure if this is the best way to fix it but I have updated the function to support the previous format and the new format. I got my camera back with this fix, however it only works with internal webcam. Not sure why I can't get the output from my external webcams. I have selected the right camera in settings yet always get the video from built-in macbook one.